### PR TITLE
Add public installer UI with configuration workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/public/uploads/
+/shared/
+.env
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,84 @@
-# geo
-A Geo Photo library
+# Geo Photothek
+
+Eine PHP/MySQL-Anwendung, um Reise-Fotos mit Geo-Informationen zu verwalten.
+
+## Funktionen
+
+- 🌍 Weltkarte (Leaflet) mit Markern für alle hochgeladenen Fotos
+- 🏠 Home-Schaltfläche auf der Karte zum schnellen Zurücksetzen der Ansicht
+- 📸 Foto-Upload mit automatischer Auswertung von EXIF-Koordinaten (falls vorhanden)
+- 👥 Multi-User mit Registrierung/Login
+- ✅ Neue Nutzer:innen müssen durch Admins freigeschaltet werden (der erste Account wird automatisch Admin)
+- 🗂️ Eigene Kategorien für Fotos verwalten und beim Upload zuweisen
+- 🎨 Kategorien lassen sich mit individuellen Farben versehen; Marker übernehmen automatisch die gewählte Farbe
+- 🔐 Geteilte Weltkarten lassen sich auf ausgewählte Kategorien einschränken, Links können neu erzeugt oder gelöscht werden
+- 🔗 Teilen der eigenen Weltkarte über einen öffentlichen Link
+- 🗂️ Verwaltung von Fotos im Dashboard mit Beschreibung und Aufnahmezeit
+- 🖼️ Detailansicht mit Originalbild nach Klick auf eine Pinnadel oder Foto-Kachel
+
+## Voraussetzungen
+
+- PHP 8.1 oder höher mit aktivierten Erweiterungen `pdo_mysql`, `fileinfo`, `exif`
+- MySQL 8 oder kompatible MariaDB-Version
+- Composer (optional für spätere Erweiterungen)
+- Ein Webserver (z. B. PHP Built-in Server, Apache, Nginx)
+
+## Installation
+
+1. Repository klonen und Abhängigkeiten installieren (falls benötigt):
+
+   ```bash
+   git clone <repo>
+   cd geo
+   ```
+
+2. Datenbank anlegen (falls noch nicht geschehen):
+
+   ```bash
+   mysql -u root -p -e "CREATE DATABASE geo_photothek CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+   ```
+
+3. Installations-/Upgrade-Assistent im Browser ausführen und Konfiguration speichern:
+
+   ```bash
+   php -S localhost:8000 -t public
+   ```
+
+   Rufe anschließend `http://localhost:8000/install.php` auf, trage deine Datenbank-Zugangsdaten ein und starte die Schema-Installation. Nach erfolgreicher Einrichtung sollte `public/install.php` aus Sicherheitsgründen gelöscht werden.
+
+   - In `config/config.php` kannst du anschließend Pfade und Limits wie `upload_dir`, `original_upload_dir` oder `display_max_dimension` nach Bedarf anpassen.
+
+   > Tipp: Die Routine lässt sich alternativ per CLI starten (`php public/install.php`), sofern `config/config.php` bereits ausgefüllt ist.
+
+4. Upload- und Shared-Verzeichnisse (inklusive Originalbildern) sicher beschreibbar machen:
+
+   ```bash
+   mkdir -p public/uploads public/uploads/originals shared
+   chmod 775 public/uploads public/uploads/originals shared
+   ```
+
+   > Upgrade-Hinweis: Bestehende Installationen sollten nach dem Update die Spalte `original_file_path` ergänzen und mit den bisherigen Dateinamen füllen, z. B.:
+   >
+   > ```sql
+   > ALTER TABLE photos ADD COLUMN original_file_path VARCHAR(255) NOT NULL DEFAULT '';
+   > UPDATE photos SET original_file_path = file_path WHERE original_file_path = '';
+   > ```
+   >
+   > Zusätzlich benötigen Kategorien nun eine Farbinformation:
+   >
+   > ```sql
+   > ALTER TABLE categories ADD COLUMN color CHAR(7) NOT NULL DEFAULT '#3388FF';
+   > UPDATE categories SET color = '#3388FF' WHERE color IS NULL OR color = '';
+   > ```
+
+5. Im Browser `http://localhost:8000` öffnen, registrieren und Fotos hochladen.
+
+## Sicherheitshinweise
+
+- Für die Produktion sollten Uploads in ein Verzeichnis außerhalb des Webroots gelegt und über einen Controller ausgeliefert werden.
+- HTTPS verwenden, Sessions absichern und weitere Prüfungen (z. B. CSRF) ergänzen.
+- Die Anwendung dient als Starterprojekt und sollte vor dem produktiven Einsatz gehärtet werden.
+
+## Lizenz
+
+MIT

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,0 +1,16 @@
+<?php
+session_start();
+
+$configPath = __DIR__ . '/config/config.php';
+if (!file_exists($configPath)) {
+    $configPath = __DIR__ . '/config/config.example.php';
+}
+$config = require $configPath;
+
+spl_autoload_register(function ($class) {
+    $baseDir = __DIR__ . '/src/';
+    $file = $baseDir . str_replace('\\', '/', $class) . '.php';
+    if (file_exists($file)) {
+        require $file;
+    }
+});

--- a/config/config.example.php
+++ b/config/config.example.php
@@ -1,0 +1,20 @@
+<?php
+return [
+    'db' => [
+        'host' => '127.0.0.1',
+        'port' => 3306,
+        'database' => 'geo_photothek',
+        'username' => 'geo_user',
+        'password' => 'secret',
+        'charset' => 'utf8mb4',
+    ],
+    'app' => [
+        'base_url' => 'http://localhost:8000',
+        'upload_dir' => __DIR__ . '/../public/uploads',
+        'original_upload_dir' => __DIR__ . '/../public/uploads/originals',
+        'shared_dir' => __DIR__ . '/../shared',
+        'max_upload_size' => 10 * 1024 * 1024, // 10MB
+        'allowed_types' => ['image/jpeg', 'image/png', 'image/heic'],
+        'display_max_dimension' => 1600,
+    ],
+];

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,58 @@
+CREATE TABLE users (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(120) NOT NULL,
+    email VARCHAR(190) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    is_admin TINYINT(1) NOT NULL DEFAULT 0,
+    is_approved TINYINT(1) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE photos (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    user_id INT UNSIGNED NOT NULL,
+    title VARCHAR(255) NULL,
+    description TEXT NULL,
+    file_path VARCHAR(255) NOT NULL,
+    original_file_path VARCHAR(255) NOT NULL,
+    latitude DECIMAL(10,8) NULL,
+    longitude DECIMAL(11,8) NULL,
+    taken_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE categories (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    user_id INT UNSIGNED NOT NULL,
+    name VARCHAR(120) NOT NULL,
+    color CHAR(7) NOT NULL DEFAULT '#3388FF',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY user_category (user_id, name),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE photo_categories (
+    photo_id INT UNSIGNED NOT NULL,
+    category_id INT UNSIGNED NOT NULL,
+    PRIMARY KEY (photo_id, category_id),
+    FOREIGN KEY (photo_id) REFERENCES photos(id) ON DELETE CASCADE,
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE shared_maps (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    user_id INT UNSIGNED NOT NULL UNIQUE,
+    share_token CHAR(32) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE shared_map_categories (
+    shared_map_id INT UNSIGNED NOT NULL,
+    category_id INT UNSIGNED NOT NULL,
+    PRIMARY KEY (shared_map_id, category_id),
+    FOREIGN KEY (shared_map_id) REFERENCES shared_maps(id) ON DELETE CASCADE,
+    FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -1,0 +1,414 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$db = Database::getInstance($config['db'])->getConnection();
+$auth = new Auth($db);
+$auth->requireLogin();
+$user = $auth->user();
+
+$categoryRepo = new CategoryRepository($db);
+$photoRepo = new PhotoRepository($db, $config['app'], $categoryRepo);
+$photoService = new PhotoService($photoRepo, $categoryRepo, $config['app']);
+$userRepo = new UserRepository($db);
+
+$error = null;
+$success = null;
+$photoError = null;
+$photoSuccess = null;
+$categoryError = null;
+$categorySuccess = null;
+$shareSuccess = null;
+$shareError = null;
+$adminSuccess = null;
+$adminError = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['action'] ?? null;
+
+    switch ($action) {
+        case 'upload':
+            if (isset($_FILES['photo'])) {
+                try {
+                    $categoryIds = array_map('intval', $_POST['categories'] ?? []);
+                    $photoService->handleUpload($_FILES['photo'], $_POST, $user['id'], $categoryIds);
+                    $success = 'Foto erfolgreich hochgeladen!';
+                } catch (Throwable $e) {
+                    $error = $e->getMessage();
+                }
+            }
+            break;
+        case 'add_category':
+            $name = trim($_POST['new_category'] ?? '');
+            $color = trim($_POST['new_category_color'] ?? '');
+            if ($name === '') {
+                $categoryError = 'Bitte einen Kategorienamen eingeben.';
+            } elseif ($color !== '' && !preg_match('/^#([0-9a-fA-F]{6})$/', $color)) {
+                $categoryError = 'Bitte eine gültige Farbe im Format #RRGGBB wählen.';
+            } else {
+                $createdId = $categoryRepo->create($user['id'], $name, $color);
+                if ($createdId) {
+                    $categorySuccess = 'Kategorie hinzugefügt.';
+                } else {
+                    $categoryError = 'Kategorie konnte nicht gespeichert werden (existiert sie bereits?).';
+                }
+            }
+            break;
+        case 'update_category_color':
+            $categoryId = (int)($_POST['category_id'] ?? 0);
+            $color = trim($_POST['category_color'] ?? '');
+            if ($categoryId <= 0) {
+                $categoryError = 'Ungültige Kategorie.';
+                break;
+            }
+            if ($color !== '' && !preg_match('/^#([0-9a-fA-F]{6})$/', $color)) {
+                $categoryError = 'Bitte eine gültige Farbe im Format #RRGGBB wählen.';
+                break;
+            }
+            if ($categoryRepo->updateColor($categoryId, $user['id'], $color)) {
+                $categorySuccess = 'Kategoriefarbe aktualisiert.';
+            } else {
+                $categoryError = 'Farbe konnte nicht gespeichert werden.';
+            }
+            break;
+        case 'share_update':
+            try {
+                $categoryIds = array_map('intval', $_POST['share_categories'] ?? []);
+                $photoRepo->upsertShareSettings($user['id'], $categoryIds, false);
+                $shareSuccess = 'Freigabe gespeichert.';
+            } catch (Throwable $e) {
+                $shareError = $e->getMessage();
+            }
+            break;
+        case 'share_regenerate':
+            try {
+                $categoryIds = array_map('intval', $_POST['share_categories'] ?? []);
+                $photoRepo->upsertShareSettings($user['id'], $categoryIds, true);
+                $shareSuccess = 'Neuer Freigabelink erstellt.';
+            } catch (Throwable $e) {
+                $shareError = $e->getMessage();
+            }
+            break;
+        case 'share_delete':
+            $photoRepo->deleteShare($user['id']);
+            $shareSuccess = 'Freigabelink entfernt.';
+            break;
+        case 'delete_photo':
+            $photoId = (int)($_POST['photo_id'] ?? 0);
+            if ($photoId <= 0) {
+                $photoError = 'Ungültiges Foto.';
+                break;
+            }
+            try {
+                $photoService->deletePhoto($photoId, $user['id']);
+                $photoSuccess = 'Foto wurde gelöscht.';
+            } catch (Throwable $e) {
+                $photoError = $e->getMessage();
+            }
+            break;
+        case 'approve_user':
+            if ($auth->isAdmin()) {
+                $userIdToApprove = (int)($_POST['user_id'] ?? 0);
+                if ($userIdToApprove > 0) {
+                    $userRepo->approve($userIdToApprove);
+                    $adminSuccess = 'Benutzer erfolgreich freigeschaltet.';
+                }
+            } else {
+                $adminError = 'Keine Berechtigung.';
+            }
+            break;
+    }
+}
+
+$categories = $categoryRepo->findByUser($user['id']);
+$photos = $photoRepo->findByUser($user['id']);
+$shareSettings = $photoRepo->getShareSettings($user['id']);
+$pendingUsers = $auth->isAdmin() ? $userRepo->findPending() : [];
+
+$photosForJs = array_map(static function (array $photo) {
+    $photo['image_url'] = '/uploads/' . $photo['file_path'];
+    $photo['original_image_url'] = !empty($photo['original_file_path'])
+        ? '/uploads/' . $photo['original_file_path']
+        : $photo['image_url'];
+    return $photo;
+}, $photos);
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Geo Photothek - Dashboard</title>
+    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js" defer></script>
+    <script>window.PHOTOS = <?php echo json_encode($photosForJs, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>;</script>
+    <script src="/map.js" defer></script>
+</head>
+<body>
+<header class="topbar">
+    <div class="brand">Geo Photothek</div>
+    <nav class="main-nav">
+        <a href="#dashboard">Dashboard</a>
+        <a href="#upload">Upload</a>
+        <a href="#map-section">Karte</a>
+        <a href="#photos">Bilder</a>
+        <a href="#share">Freigabe</a>
+    </nav>
+    <div class="user-info">
+        <span>Hallo <?php echo htmlspecialchars($user['name'], ENT_QUOTES); ?></span>
+        <a class="button" href="/logout.php">Logout</a>
+    </div>
+</header>
+<main id="dashboard" class="layout">
+    <section class="panel" id="upload">
+        <h2>Foto hochladen</h2>
+        <?php if ($error): ?>
+            <div class="error"><?php echo htmlspecialchars($error, ENT_QUOTES); ?></div>
+        <?php endif; ?>
+        <?php if ($success): ?>
+            <div class="success"><?php echo htmlspecialchars($success, ENT_QUOTES); ?></div>
+        <?php endif; ?>
+        <form method="post" enctype="multipart/form-data">
+            <input type="hidden" name="action" value="upload">
+            <label for="title">Titel</label>
+            <input type="text" name="title" id="title" placeholder="Titel des Fotos">
+
+            <label for="description">Beschreibung</label>
+            <textarea name="description" id="description" rows="3" placeholder="Beschreibung"></textarea>
+
+            <label for="photo">Foto</label>
+            <input type="file" name="photo" id="photo" accept="image/*" required>
+
+            <?php if (!empty($categories)): ?>
+                <fieldset class="category-select">
+                    <legend>Kategorien</legend>
+                    <?php foreach ($categories as $category): ?>
+                        <?php $categoryColor = $category['color'] ?? '#3388FF'; ?>
+                        <label class="checkbox">
+                            <input type="checkbox" name="categories[]" value="<?php echo (int)$category['id']; ?>">
+                            <span class="color-dot" style="--dot-color: <?php echo htmlspecialchars($categoryColor, ENT_QUOTES); ?>"></span>
+                            <span><?php echo htmlspecialchars($category['name'], ENT_QUOTES); ?></span>
+                        </label>
+                    <?php endforeach; ?>
+                </fieldset>
+            <?php else: ?>
+                <p class="hint">Noch keine Kategorien vorhanden. Du kannst unten welche hinzufügen.</p>
+            <?php endif; ?>
+
+            <button type="submit">Hochladen</button>
+        </form>
+        <section class="category-manager" id="categories">
+            <h3>Kategorie hinzufügen</h3>
+            <?php if ($categoryError): ?>
+                <div class="error"><?php echo htmlspecialchars($categoryError, ENT_QUOTES); ?></div>
+            <?php endif; ?>
+            <?php if ($categorySuccess): ?>
+                <div class="success"><?php echo htmlspecialchars($categorySuccess, ENT_QUOTES); ?></div>
+            <?php endif; ?>
+            <form method="post" class="category-form">
+                <input type="hidden" name="action" value="add_category">
+                <label for="new_category">Name der Kategorie</label>
+                <input type="text" id="new_category" name="new_category" placeholder="z. B. Männerurlaub">
+                <label for="new_category_color">Farbe</label>
+                <input type="color" id="new_category_color" name="new_category_color" value="#3388FF">
+                <button type="submit">Kategorie speichern</button>
+            </form>
+            <?php if (!empty($categories)): ?>
+                <h4>Vorhandene Kategorien</h4>
+                <ul class="category-color-list">
+                    <?php foreach ($categories as $category): ?>
+                        <?php $categoryColor = $category['color'] ?? '#3388FF'; ?>
+                        <li>
+                            <form method="post" class="category-color-form">
+                                <input type="hidden" name="action" value="update_category_color">
+                                <input type="hidden" name="category_id" value="<?php echo (int)$category['id']; ?>">
+                                <span class="color-dot" style="--dot-color: <?php echo htmlspecialchars($categoryColor, ENT_QUOTES); ?>"></span>
+                                <span class="category-name"><?php echo htmlspecialchars($category['name'], ENT_QUOTES); ?></span>
+                                <input type="color" name="category_color" value="<?php echo htmlspecialchars($categoryColor, ENT_QUOTES); ?>">
+                                <button type="submit">Speichern</button>
+                            </form>
+                        </li>
+                    <?php endforeach; ?>
+                </ul>
+            <?php endif; ?>
+        </section>
+        <section class="share" id="share">
+            <h3>Weltkugel teilen</h3>
+            <?php if ($shareError): ?>
+                <div class="error"><?php echo htmlspecialchars($shareError, ENT_QUOTES); ?></div>
+            <?php endif; ?>
+            <?php if ($shareSuccess): ?>
+                <div class="success"><?php echo htmlspecialchars($shareSuccess, ENT_QUOTES); ?></div>
+            <?php endif; ?>
+            <form method="post" class="share-form">
+                <input type="hidden" name="action" value="share_update">
+                <p>Wähle, welche Kategorien über den Freigabelink sichtbar sein sollen.</p>
+                <div class="category-list">
+                    <?php foreach ($categories as $category): ?>
+                        <?php $categoryColor = $category['color'] ?? '#3388FF'; ?>
+                        <label class="checkbox">
+                            <input type="checkbox" name="share_categories[]" value="<?php echo (int)$category['id']; ?>" <?php echo in_array((int)$category['id'], $shareSettings['categories'], true) ? 'checked' : ''; ?>>
+                            <span class="color-dot" style="--dot-color: <?php echo htmlspecialchars($categoryColor, ENT_QUOTES); ?>"></span>
+                            <span><?php echo htmlspecialchars($category['name'], ENT_QUOTES); ?></span>
+                        </label>
+                    <?php endforeach; ?>
+                </div>
+                <p class="hint">Ohne Auswahl werden alle Fotos geteilt.</p>
+                <button type="submit">Freigabe speichern</button>
+            </form>
+            <?php if ($shareSettings['token']): ?>
+                <form method="post" class="share-form inline">
+                    <input type="hidden" name="action" value="share_regenerate">
+                    <?php foreach ($shareSettings['categories'] as $categoryId): ?>
+                        <input type="hidden" name="share_categories[]" value="<?php echo (int)$categoryId; ?>">
+                    <?php endforeach; ?>
+                    <button type="submit">Neuen Link erzeugen</button>
+                </form>
+                <form method="post" class="share-form inline">
+                    <input type="hidden" name="action" value="share_delete">
+                    <button type="submit" class="danger">Freigabelink löschen</button>
+                </form>
+            <?php endif; ?>
+            <?php if ($shareSettings['url']): ?>
+                <div class="share-link">
+                    <span>Aktueller Link:</span>
+                    <input type="text" value="<?php echo htmlspecialchars($shareSettings['url'], ENT_QUOTES); ?>" readonly onclick="this.select();">
+                </div>
+            <?php endif; ?>
+        </section>
+        <?php if ($auth->isAdmin()): ?>
+            <section class="admin-approval" id="approvals">
+                <h3>Benutzerfreigaben</h3>
+                <?php if ($adminError): ?>
+                    <div class="error"><?php echo htmlspecialchars($adminError, ENT_QUOTES); ?></div>
+                <?php endif; ?>
+                <?php if ($adminSuccess): ?>
+                    <div class="success"><?php echo htmlspecialchars($adminSuccess, ENT_QUOTES); ?></div>
+                <?php endif; ?>
+                <?php if (empty($pendingUsers)): ?>
+                    <p>Keine Benutzer warten auf Freigabe.</p>
+                <?php else: ?>
+                    <ul class="pending-users">
+                        <?php foreach ($pendingUsers as $pending): ?>
+                            <li>
+                                <div>
+                                    <strong><?php echo htmlspecialchars($pending['name'], ENT_QUOTES); ?></strong><br>
+                                    <span><?php echo htmlspecialchars($pending['email'], ENT_QUOTES); ?></span>
+                                </div>
+                                <form method="post">
+                                    <input type="hidden" name="action" value="approve_user">
+                                    <input type="hidden" name="user_id" value="<?php echo (int)$pending['id']; ?>">
+                                    <button type="submit">Freigeben</button>
+                                </form>
+                            </li>
+                        <?php endforeach; ?>
+                    </ul>
+                <?php endif; ?>
+            </section>
+        <?php endif; ?>
+    </section>
+    <section class="map-panel" id="map-section">
+        <h2>Karte</h2>
+        <div id="map"></div>
+        <aside class="photo-detail" data-photo-detail>
+            <div class="detail-empty" data-photo-detail-empty>
+                <h3>Details</h3>
+                <p>Wähle eine Pinnadel oder ein Foto aus der Liste, um mehr Informationen zu sehen.</p>
+            </div>
+            <div class="detail-body hidden" data-photo-detail-body>
+                <button type="button" class="detail-close" data-photo-detail-close aria-label="Detailansicht schließen">&times;</button>
+                <img src="" alt="" data-photo-detail-image>
+                <div class="detail-meta">
+                    <h3 data-photo-detail-title></h3>
+                    <p data-photo-detail-description></p>
+                    <dl>
+                        <div class="detail-row" data-photo-detail-categories-row>
+                            <dt>Kategorien</dt>
+                            <dd data-photo-detail-categories></dd>
+                        </div>
+                        <div class="detail-row" data-photo-detail-coordinates-row>
+                            <dt>Koordinaten</dt>
+                            <dd data-photo-detail-coordinates></dd>
+                        </div>
+                        <div class="detail-row" data-photo-detail-date-row>
+                            <dt>Aufgenommen am</dt>
+                            <dd data-photo-detail-date></dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </aside>
+    </section>
+</main>
+<section class="photo-list" id="photos">
+    <div class="photo-list-header">
+        <h2>Bilder</h2>
+        <div class="photo-list-messages">
+            <?php if ($photoError): ?>
+                <div class="error"><?php echo htmlspecialchars($photoError, ENT_QUOTES); ?></div>
+            <?php endif; ?>
+            <?php if ($photoSuccess): ?>
+                <div class="success"><?php echo htmlspecialchars($photoSuccess, ENT_QUOTES); ?></div>
+            <?php endif; ?>
+        </div>
+    </div>
+    <?php if (empty($photos)): ?>
+        <p class="hint">Noch keine Fotos vorhanden. Lade dein erstes Bild hoch!</p>
+    <?php else: ?>
+        <div class="table-wrapper">
+            <table class="photo-table">
+                <thead>
+                    <tr>
+                        <th scope="col">Vorschau</th>
+                        <th scope="col">Details</th>
+                        <th scope="col">Kategorien</th>
+                        <th scope="col">Aktionen</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($photos as $photo): ?>
+                    <?php $photoTitleAttr = htmlspecialchars($photo['title'] ?? 'Ohne Titel', ENT_QUOTES); ?>
+                    <tr class="photo-row" data-photo-card data-photo-id="<?php echo (int)$photo['id']; ?>" tabindex="0" role="button" aria-label="Foto-Details anzeigen: <?php echo $photoTitleAttr; ?>">
+                        <td class="photo-thumb">
+                            <img src="/uploads/<?php echo htmlspecialchars($photo['file_path'], ENT_QUOTES); ?>" alt="<?php echo htmlspecialchars($photo['title'] ?? 'Foto', ENT_QUOTES); ?>">
+                        </td>
+                        <td class="photo-info">
+                            <strong><?php echo htmlspecialchars($photo['title'] ?? 'Ohne Titel', ENT_QUOTES); ?></strong>
+                            <?php if (!empty($photo['description'])): ?>
+                                <div class="photo-description"><?php echo nl2br(htmlspecialchars($photo['description'], ENT_QUOTES)); ?></div>
+                            <?php endif; ?>
+                            <?php if ($photo['taken_at']): ?>
+                                <div class="photo-meta-line">Aufgenommen am: <?php echo htmlspecialchars($photo['taken_at'], ENT_QUOTES); ?></div>
+                            <?php endif; ?>
+                            <?php if ($photo['latitude'] && $photo['longitude']): ?>
+                                <div class="photo-meta-line">Koordinaten: <?php echo round($photo['latitude'], 5) . ', ' . round($photo['longitude'], 5); ?></div>
+                            <?php endif; ?>
+                        </td>
+                        <td class="photo-categories-cell">
+                            <?php if (!empty($photo['category_details'])): ?>
+                                <div class="photo-categories">
+                                    <?php foreach ($photo['category_details'] as $category): ?>
+                                        <?php $categoryColor = $category['color'] ?? '#3388FF'; ?>
+                                        <span class="category-pill" style="--category-color: <?php echo htmlspecialchars($categoryColor, ENT_QUOTES); ?>"><?php echo htmlspecialchars($category['name'], ENT_QUOTES); ?></span>
+                                    <?php endforeach; ?>
+                                </div>
+                            <?php else: ?>
+                                <span class="photo-meta-line">Keine</span>
+                            <?php endif; ?>
+                        </td>
+                        <td class="photo-actions">
+                            <button type="button" class="detail-button" data-photo-trigger>Details</button>
+                            <form method="post" onsubmit="return confirm('Foto wirklich löschen?');">
+                                <input type="hidden" name="action" value="delete_photo">
+                                <input type="hidden" name="photo_id" value="<?php echo (int)$photo['id']; ?>">
+                                <button type="submit" class="danger-link">Löschen</button>
+                            </form>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+    <?php endif; ?>
+</section>
+</body>
+</html>

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,10 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$auth = new Auth(Database::getInstance($config['db'])->getConnection());
+if ($auth->user()) {
+    header('Location: /dashboard.php');
+    exit;
+}
+header('Location: /login.php');
+exit;

--- a/public/install.php
+++ b/public/install.php
@@ -1,0 +1,479 @@
+<?php
+declare(strict_types=1);
+
+$baseDir = dirname(__DIR__);
+$configDir = $baseDir . '/config';
+$configPath = $configDir . '/config.php';
+$configExamplePath = $configDir . '/config.example.php';
+$schemaPath = $baseDir . '/database/schema.sql';
+
+if (PHP_SAPI === 'cli') {
+    runCli($configPath, $configExamplePath, $schemaPath);
+    return;
+}
+
+session_start();
+
+$config = loadConfig($configPath, $configExamplePath);
+$dbConfig = $config['db'] ?? [];
+$isDbConfigured = isDbConfigComplete($dbConfig);
+$messages = [];
+$errors = [];
+$sqlResults = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (isset($_POST['save_config'])) {
+        [$dbConfig, $isDbConfigured, $messages, $errors] = handleConfigSave($_POST, $config, $configPath, $configDir, $messages, $errors);
+    }
+
+    if (isset($_POST['run_install']) && $isDbConfigured) {
+        [$messages, $errors, $sqlResults] = runSchema($dbConfig, $schemaPath, $messages, $errors);
+    } elseif (isset($_POST['run_install']) && !$isDbConfigured) {
+        $errors[] = 'Bitte zuerst gültige Datenbank-Zugangsdaten speichern.';
+    }
+}
+
+renderHtml($dbConfig, $isDbConfigured, $messages, $errors, $sqlResults, file_exists($configPath));
+
+function loadConfig(string $configPath, string $fallbackPath): array
+{
+    if (file_exists($configPath)) {
+        /** @var array $config */
+        $config = require $configPath;
+        return $config;
+    }
+
+    /** @var array $fallback */
+    $fallback = require $fallbackPath;
+    return $fallback;
+}
+
+function isDbConfigComplete(array $dbConfig): bool
+{
+    $required = ['host', 'port', 'database', 'username', 'password'];
+    foreach ($required as $key) {
+        if (!isset($dbConfig[$key]) || trim((string) $dbConfig[$key]) === '') {
+            return false;
+        }
+    }
+    return true;
+}
+
+function handleConfigSave(array $input, array $config, string $configPath, string $configDir, array $messages, array $errors): array
+{
+    $host = trim($input['db_host'] ?? '');
+    $port = (int) ($input['db_port'] ?? 3306);
+    $database = trim($input['db_database'] ?? '');
+    $username = trim($input['db_username'] ?? '');
+    $password = trim($input['db_password'] ?? '');
+    $charset = trim($input['db_charset'] ?? 'utf8mb4');
+
+    if ($host === '' || $database === '' || $username === '' || $password === '') {
+        $errors[] = 'Bitte alle Pflichtfelder ausfüllen.';
+        return [$config['db'] ?? [], false, $messages, $errors];
+    }
+
+    $config['db'] = [
+        'host' => $host,
+        'port' => $port ?: 3306,
+        'database' => $database,
+        'username' => $username,
+        'password' => $password,
+        'charset' => $charset !== '' ? $charset : 'utf8mb4',
+    ];
+
+    if (!is_dir($configDir) && !mkdir($configDir, 0775, true) && !is_dir($configDir)) {
+        $errors[] = 'Konfigurationsverzeichnis konnte nicht erstellt werden.';
+        return [$config['db'], false, $messages, $errors];
+    }
+
+    $export = var_export($config, true);
+    $content = "<?php\nreturn $export;\n";
+
+    if (file_put_contents($configPath, $content) === false) {
+        $errors[] = 'Konfigurationsdatei konnte nicht geschrieben werden.';
+        return [$config['db'], false, $messages, $errors];
+    }
+
+    $messages[] = 'Konfiguration wurde gespeichert.';
+    return [$config['db'], true, $messages, $errors];
+}
+
+function runSchema(array $dbConfig, string $schemaPath, array $messages, array $errors): array
+{
+    if (!file_exists($schemaPath)) {
+        $errors[] = 'Schema-Datei wurde nicht gefunden.';
+        return [$messages, $errors, []];
+    }
+
+    $schemaSql = file_get_contents($schemaPath);
+    if ($schemaSql === false) {
+        $errors[] = 'Schema-Datei konnte nicht gelesen werden.';
+        return [$messages, $errors, []];
+    }
+
+    require_once dirname(__DIR__) . '/src/Database.php';
+
+    try {
+        $pdo = Database::getInstance($dbConfig)->getConnection();
+    } catch (Throwable $e) {
+        $errors[] = 'Verbindung zur Datenbank fehlgeschlagen: ' . $e->getMessage();
+        return [$messages, $errors, []];
+    }
+
+    $statements = array_filter(array_map('trim', preg_split('/;\s*(?:\R|$)/', $schemaSql)));
+    $results = [];
+    $hadErrors = false;
+
+    foreach ($statements as $statement) {
+        if ($statement === '') {
+            continue;
+        }
+
+        try {
+            $pdo->exec($statement);
+            $results[] = ['statement' => $statement, 'success' => true];
+        } catch (Throwable $e) {
+            $hadErrors = true;
+            $results[] = [
+                'statement' => $statement,
+                'success' => false,
+                'message' => $e->getMessage(),
+            ];
+        }
+    }
+
+    if ($hadErrors) {
+        $errors[] = 'Es sind Fehler beim Ausführen des Schemas aufgetreten. Details siehe unten.';
+    } else {
+        $messages[] = 'Schema wurde erfolgreich ausgeführt.';
+    }
+
+    return [$messages, $errors, $results];
+}
+
+function renderHtml(array $dbConfig, bool $isDbConfigured, array $messages, array $errors, array $sqlResults, bool $configExists): void
+{
+    $title = 'Geo Photothek Installation & Upgrade';
+    $baseUrl = htmlspecialchars((($_SERVER['REQUEST_SCHEME'] ?? 'http') . '://' . ($_SERVER['HTTP_HOST'] ?? 'localhost')), ENT_QUOTES, 'UTF-8');
+    $deleteNotice = 'Bitte lösche diese Datei nach der Einrichtung aus dem public-Verzeichnis.';
+    ?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= $title ?></title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            font-family: 'Segoe UI', Roboto, sans-serif;
+            --bg: #f2f5f9;
+            --bg-card: #ffffff;
+            --border: #d0d6e1;
+            --text: #1c2733;
+            --accent: #0060df;
+            --danger: #c92a2a;
+            --success: #0f9d58;
+        }
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+            display: flex;
+            min-height: 100vh;
+            align-items: center;
+            justify-content: center;
+            padding: 32px 16px;
+        }
+        .card {
+            background: var(--bg-card);
+            border-radius: 16px;
+            box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+            max-width: 960px;
+            width: 100%;
+            padding: 32px;
+        }
+        h1 {
+            margin-top: 0;
+            font-size: 2rem;
+        }
+        p.lead {
+            margin-top: 0.25rem;
+            color: rgba(28, 39, 51, 0.75);
+        }
+        form {
+            margin-top: 24px;
+        }
+        label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: 4px;
+        }
+        input[type="text"],
+        input[type="number"],
+        input[type="password"] {
+            width: 100%;
+            padding: 10px 12px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            font-size: 1rem;
+            transition: border-color 0.2s ease;
+        }
+        input:focus {
+            border-color: var(--accent);
+            outline: none;
+            box-shadow: 0 0 0 2px rgba(0, 96, 223, 0.15);
+        }
+        .grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 16px;
+        }
+        .actions {
+            margin-top: 24px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+        button {
+            border: none;
+            border-radius: 999px;
+            padding: 12px 24px;
+            font-size: 1rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+        button.primary {
+            background: linear-gradient(135deg, #1e3c72 0%, #2a5298 100%);
+            color: #fff;
+            box-shadow: 0 12px 24px rgba(30, 60, 114, 0.35);
+        }
+        button.secondary {
+            background: #e2e8f0;
+            color: #1c2733;
+        }
+        button:hover {
+            transform: translateY(-1px);
+        }
+        .notice {
+            border-radius: 12px;
+            padding: 16px 18px;
+            margin-top: 16px;
+            background: rgba(0, 96, 223, 0.08);
+            border: 1px solid rgba(0, 96, 223, 0.15);
+        }
+        .messages, .errors {
+            border-radius: 12px;
+            padding: 16px 18px;
+            margin-top: 16px;
+        }
+        .messages {
+            background: rgba(15, 157, 88, 0.1);
+            border: 1px solid rgba(15, 157, 88, 0.2);
+        }
+        .errors {
+            background: rgba(201, 42, 42, 0.1);
+            border: 1px solid rgba(201, 42, 42, 0.2);
+        }
+        ul {
+            margin: 0;
+            padding-left: 20px;
+        }
+        .sql-results {
+            margin-top: 24px;
+            border-collapse: collapse;
+            width: 100%;
+            font-size: 0.95rem;
+        }
+        .sql-results th,
+        .sql-results td {
+            padding: 12px 10px;
+            border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+            vertical-align: top;
+        }
+        .sql-results th {
+            text-align: left;
+            font-weight: 600;
+        }
+        .sql-results tr:last-child td {
+            border-bottom: none;
+        }
+        .sql-results .ok {
+            color: var(--success);
+            font-weight: 600;
+        }
+        .sql-results .fail {
+            color: var(--danger);
+            font-weight: 600;
+        }
+        .footer {
+            margin-top: 32px;
+            font-size: 0.85rem;
+            color: rgba(28, 39, 51, 0.65);
+            text-align: center;
+        }
+        .badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            background: rgba(15, 23, 42, 0.05);
+            border-radius: 999px;
+            padding: 6px 12px;
+            font-size: 0.85rem;
+        }
+        @media (max-width: 600px) {
+            .card {
+                padding: 24px;
+            }
+            button {
+                width: 100%;
+                justify-content: center;
+            }
+        }
+    </style>
+</head>
+<body>
+    <main class="card">
+        <header>
+            <h1><?= $title ?></h1>
+            <p class="lead">Führe die Datenbankinstallation oder -aktualisierung für deine Geo Photothek durch.</p>
+            <div class="notice">
+                <strong>Hinweis:</strong> <?= htmlspecialchars($deleteNotice, ENT_QUOTES, 'UTF-8') ?>
+            </div>
+        </header>
+
+        <?php if ($messages): ?>
+            <section class="messages">
+                <ul>
+                    <?php foreach ($messages as $message): ?>
+                        <li><?= htmlspecialchars($message, ENT_QUOTES, 'UTF-8') ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </section>
+        <?php endif; ?>
+
+        <?php if ($errors): ?>
+            <section class="errors">
+                <ul>
+                    <?php foreach ($errors as $error): ?>
+                        <li><?= htmlspecialchars($error, ENT_QUOTES, 'UTF-8') ?></li>
+                    <?php endforeach; ?>
+                </ul>
+            </section>
+        <?php endif; ?>
+
+        <section>
+            <h2>1. Datenbankzugang</h2>
+            <p>Hinterlege die Verbindungsdaten für deine MySQL/MariaDB-Datenbank. Die Angaben werden in <code>config/config.php</code> gespeichert.</p>
+            <form method="post" class="config-form">
+                <div class="grid">
+                    <div>
+                        <label for="db_host">Host *</label>
+                        <input type="text" id="db_host" name="db_host" value="<?= htmlspecialchars($dbConfig['host'] ?? '', ENT_QUOTES, 'UTF-8') ?>" required>
+                    </div>
+                    <div>
+                        <label for="db_port">Port *</label>
+                        <input type="number" id="db_port" name="db_port" value="<?= htmlspecialchars((string)($dbConfig['port'] ?? 3306), ENT_QUOTES, 'UTF-8') ?>" min="1" required>
+                    </div>
+                    <div>
+                        <label for="db_database">Datenbank *</label>
+                        <input type="text" id="db_database" name="db_database" value="<?= htmlspecialchars($dbConfig['database'] ?? '', ENT_QUOTES, 'UTF-8') ?>" required>
+                    </div>
+                    <div>
+                        <label for="db_username">Benutzername *</label>
+                        <input type="text" id="db_username" name="db_username" value="<?= htmlspecialchars($dbConfig['username'] ?? '', ENT_QUOTES, 'UTF-8') ?>" required>
+                    </div>
+                    <div>
+                        <label for="db_password">Passwort *</label>
+                        <input type="password" id="db_password" name="db_password" value="<?= htmlspecialchars($dbConfig['password'] ?? '', ENT_QUOTES, 'UTF-8') ?>" required>
+                    </div>
+                    <div>
+                        <label for="db_charset">Zeichensatz</label>
+                        <input type="text" id="db_charset" name="db_charset" value="<?= htmlspecialchars($dbConfig['charset'] ?? 'utf8mb4', ENT_QUOTES, 'UTF-8') ?>">
+                    </div>
+                </div>
+                <div class="actions">
+                    <button type="submit" name="save_config" class="primary">Konfiguration speichern</button>
+                    <?php if ($configExists): ?>
+                        <span class="badge">Speicherort: config/config.php</span>
+                    <?php endif; ?>
+                </div>
+            </form>
+        </section>
+
+        <section>
+            <h2>2. Schema anwenden</h2>
+            <p>Installiere oder aktualisiere das Datenbankschema aus <code>database/schema.sql</code>.</p>
+            <form method="post">
+                <div class="actions">
+                    <button type="submit" name="run_install" class="secondary" <?= $isDbConfigured ? '' : 'disabled' ?>>Schema ausführen</button>
+                </div>
+            </form>
+            <?php if (!$isDbConfigured): ?>
+                <p class="lead">Bitte speichere zuerst gültige Datenbank-Zugangsdaten.</p>
+            <?php endif; ?>
+        </section>
+
+        <?php if ($sqlResults): ?>
+            <section>
+                <h2>Protokoll</h2>
+                <table class="sql-results">
+                    <thead>
+                        <tr>
+                            <th>Status</th>
+                            <th>Anweisung</th>
+                            <th>Nachricht</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($sqlResults as $result): ?>
+                            <tr>
+                                <td class="<?= $result['success'] ? 'ok' : 'fail' ?>"><?= $result['success'] ? 'OK' : 'Fehler' ?></td>
+                                <td><code><?= htmlspecialchars($result['statement'], ENT_QUOTES, 'UTF-8') ?></code></td>
+                                <td><?= isset($result['message']) ? htmlspecialchars($result['message'], ENT_QUOTES, 'UTF-8') : '–' ?></td>
+                            </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </section>
+        <?php endif; ?>
+
+        <footer class="footer">
+            &copy; <?= date('Y') ?> Geo Photothek – Admin-Werkzeug. URL: <?= $baseUrl ?>/install.php
+        </footer>
+    </main>
+</body>
+</html>
+<?php
+}
+
+function runCli(string $configPath, string $fallbackPath, string $schemaPath): void
+{
+    $config = loadConfig($configPath, $fallbackPath);
+    $dbConfig = $config['db'] ?? [];
+
+    if (!isDbConfigComplete($dbConfig)) {
+        fwrite(STDERR, "Konfiguration unvollständig. Bitte install.php im Browser aufrufen, um die Zugangsdaten zu hinterlegen." . PHP_EOL);
+        exit(1);
+    }
+
+    [$messages, $errors, $results] = runSchema($dbConfig, $schemaPath, [], []);
+
+    foreach ($messages as $message) {
+        fwrite(STDOUT, $message . PHP_EOL);
+    }
+
+    if ($errors) {
+        foreach ($errors as $error) {
+            fwrite(STDERR, $error . PHP_EOL);
+        }
+        foreach ($results as $result) {
+            fwrite(STDERR, sprintf('[%s] %s%s', $result['success'] ? 'OK' : 'ERR', $result['statement'], isset($result['message']) ? ' — ' . $result['message'] : '') . PHP_EOL);
+        }
+        exit(1);
+    }
+
+    exit(0);
+}

--- a/public/login.php
+++ b/public/login.php
@@ -1,0 +1,41 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$pdo = Database::getInstance($config['db'])->getConnection();
+$auth = new Auth($pdo);
+
+$error = null;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if ($auth->attempt($_POST['email'] ?? '', $_POST['password'] ?? '')) {
+        header('Location: /dashboard.php');
+        exit;
+    }
+    $error = $auth->lastError() ?? 'Anmeldung fehlgeschlagen.';
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Geo Photothek - Login</title>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+    <div class="auth-container">
+        <h1>Geo Photothek</h1>
+        <?php if ($error): ?>
+            <div class="error"><?php echo htmlspecialchars($error, ENT_QUOTES); ?></div>
+        <?php endif; ?>
+        <form method="post">
+            <label for="email">E-Mail</label>
+            <input type="email" id="email" name="email" required>
+
+            <label for="password">Passwort</label>
+            <input type="password" id="password" name="password" required>
+
+            <button type="submit">Login</button>
+        </form>
+        <p>Noch keinen Account? <a href="/register.php">Jetzt registrieren</a></p>
+    </div>
+</body>
+</html>

--- a/public/logout.php
+++ b/public/logout.php
@@ -1,0 +1,7 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$auth = new Auth(Database::getInstance($config['db'])->getConnection());
+$auth->logout();
+header('Location: /login.php');
+exit;

--- a/public/map.js
+++ b/public/map.js
@@ -1,0 +1,319 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const allPhotos = window.PHOTOS || [];
+    const photoIndex = new Map();
+    allPhotos.forEach(photo => {
+        const id = Number(photo.id);
+        if (Number.isFinite(id)) {
+            photoIndex.set(id, photo);
+        }
+    });
+
+    const sanitizeColor = (input) => {
+        if (typeof input !== 'string') {
+            return '#3388FF';
+        }
+        const trimmed = input.trim();
+        const match = trimmed.match(/^#([0-9a-fA-F]{6})$/);
+        if (!match) {
+            return '#3388FF';
+        }
+        return `#${match[1].toUpperCase()}`;
+    };
+
+    const escapeHtml = (value) => String(value ?? '').replace(/[&<>"']/g, (char) => {
+        switch (char) {
+            case '&':
+                return '&amp;';
+            case '<':
+                return '&lt;';
+            case '>':
+                return '&gt;';
+            case '"':
+                return '&quot;';
+            case "'":
+                return '&#39;';
+            default:
+                return char;
+        }
+    });
+
+    const renderCategoryBadges = (categories) => {
+        if (!Array.isArray(categories) || categories.length === 0) {
+            return '';
+        }
+        return categories.map((category) => {
+            const name = escapeHtml(category?.name ?? '');
+            const color = sanitizeColor(category?.color);
+            return `<span class="category-pill" style="--category-color: ${color}">${name}</span>`;
+        }).join(' ');
+    };
+
+    const detail = document.querySelector('[data-photo-detail]');
+    const detailEmpty = detail ? detail.querySelector('[data-photo-detail-empty]') : null;
+    const detailBody = detail ? detail.querySelector('[data-photo-detail-body]') : null;
+    const detailImage = detail ? detail.querySelector('[data-photo-detail-image]') : null;
+    const detailTitle = detail ? detail.querySelector('[data-photo-detail-title]') : null;
+    const detailDescription = detail ? detail.querySelector('[data-photo-detail-description]') : null;
+    const detailCategories = detail ? detail.querySelector('[data-photo-detail-categories]') : null;
+    const detailCategoriesRow = detail ? detail.querySelector('[data-photo-detail-categories-row]') : null;
+    const detailCoordinates = detail ? detail.querySelector('[data-photo-detail-coordinates]') : null;
+    const detailCoordinatesRow = detail ? detail.querySelector('[data-photo-detail-coordinates-row]') : null;
+    const detailDate = detail ? detail.querySelector('[data-photo-detail-date]') : null;
+    const detailDateRow = detail ? detail.querySelector('[data-photo-detail-date-row]') : null;
+    const detailClose = detail ? detail.querySelector('[data-photo-detail-close]') : null;
+    let activeCard = null;
+    let suppressScroll = false;
+
+    const highlightCard = (photoId) => {
+        if (activeCard) {
+            activeCard.classList.remove('active');
+            activeCard = null;
+        }
+        if (!Number.isFinite(photoId)) {
+            return;
+        }
+        const card = document.querySelector(`[data-photo-card][data-photo-id="${photoId}"]`);
+        if (card) {
+            card.classList.add('active');
+            activeCard = card;
+            if (!suppressScroll) {
+                card.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
+            }
+        }
+    };
+
+    const showDetail = (photo) => {
+        if (!detail || !photo) {
+            return;
+        }
+        if (detailEmpty) {
+            detailEmpty.classList.add('hidden');
+        }
+        if (detailBody) {
+            detailBody.classList.remove('hidden');
+        }
+        if (detailImage) {
+            const imageUrl = photo.original_image_url || photo.image_url;
+            detailImage.src = imageUrl;
+            detailImage.alt = photo.title || 'Ohne Titel';
+        }
+        if (detailTitle) {
+            detailTitle.textContent = photo.title || 'Ohne Titel';
+        }
+        if (detailDescription) {
+            if (photo.description) {
+                detailDescription.textContent = photo.description;
+                detailDescription.classList.remove('hidden');
+            } else {
+                detailDescription.textContent = '';
+                detailDescription.classList.add('hidden');
+            }
+        }
+        if (detailCategories && detailCategoriesRow) {
+            if (Array.isArray(photo.category_details) && photo.category_details.length > 0) {
+                detailCategoriesRow.classList.remove('hidden');
+                detailCategories.innerHTML = renderCategoryBadges(photo.category_details);
+            } else {
+                detailCategoriesRow.classList.add('hidden');
+                detailCategories.innerHTML = '';
+            }
+        }
+        if (detailCoordinates && detailCoordinatesRow) {
+            const lat = parseFloat(photo.latitude);
+            const lng = parseFloat(photo.longitude);
+            if (Number.isFinite(lat) && Number.isFinite(lng)) {
+                detailCoordinatesRow.classList.remove('hidden');
+                detailCoordinates.textContent = `${lat.toFixed(5)}, ${lng.toFixed(5)}`;
+            } else {
+                detailCoordinatesRow.classList.add('hidden');
+                detailCoordinates.textContent = '';
+            }
+        }
+        if (detailDate && detailDateRow) {
+            if (photo.taken_at) {
+                detailDateRow.classList.remove('hidden');
+                detailDate.textContent = photo.taken_at;
+            } else {
+                detailDateRow.classList.add('hidden');
+                detailDate.textContent = '';
+            }
+        }
+        detail.classList.add('active');
+        highlightCard(Number(photo.id));
+    };
+
+    const hideDetail = () => {
+        if (!detail) {
+            return;
+        }
+        if (detailBody) {
+            detailBody.classList.add('hidden');
+        }
+        if (detailEmpty) {
+            detailEmpty.classList.remove('hidden');
+        }
+        if (detailImage) {
+            detailImage.src = '';
+            detailImage.alt = '';
+        }
+        if (detailDescription) {
+            detailDescription.textContent = '';
+            detailDescription.classList.add('hidden');
+        }
+        if (detailCategories) {
+            detailCategories.innerHTML = '';
+        }
+        detail.classList.remove('active');
+        highlightCard(NaN);
+    };
+
+    if (detailClose) {
+        detailClose.addEventListener('click', () => {
+            hideDetail();
+        });
+    }
+
+    const mapElement = document.getElementById('map');
+    const hasLeaflet = typeof L !== 'undefined';
+    const defaultView = { center: [20, 0], zoom: 2 };
+    let map = null;
+    let bounds = null;
+
+    if (mapElement && hasLeaflet) {
+        map = L.map(mapElement).setView(defaultView.center, defaultView.zoom);
+
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> Contributors',
+            maxZoom: 18,
+        }).addTo(map);
+
+        const photosWithCoordinates = allPhotos.filter(photo => {
+            const lat = parseFloat(photo.latitude);
+            const lng = parseFloat(photo.longitude);
+            return Number.isFinite(lat) && Number.isFinite(lng);
+        });
+
+        const markers = [];
+        photosWithCoordinates.forEach(photo => {
+            const lat = parseFloat(photo.latitude);
+            const lng = parseFloat(photo.longitude);
+            if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+                return;
+            }
+            const markerColor = sanitizeColor(photo.primary_color || (photo.category_details && photo.category_details[0]?.color));
+            const marker = L.circleMarker([lat, lng], {
+                radius: 8,
+                color: markerColor,
+                fillColor: markerColor,
+                fillOpacity: 0.9,
+                weight: 2,
+            }).addTo(map);
+            const categories = Array.isArray(photo.category_details) && photo.category_details.length > 0
+                ? `<div class="popup-categories">${renderCategoryBadges(photo.category_details)}</div>`
+                : '';
+            const popupTitle = escapeHtml(photo.title || 'Ohne Titel');
+            const popupDescription = photo.description ? `<em>${escapeHtml(photo.description)}</em><br>` : '';
+            const popupTaken = photo.taken_at ? `<span class="popup-date">Aufgenommen am: ${escapeHtml(photo.taken_at)}</span><br>`
+                : '';
+            const imageUrl = typeof photo.image_url === 'string' ? escapeHtml(photo.image_url) : '';
+            const image = imageUrl
+                ? `<img src="${imageUrl}" alt="${popupTitle}" class="popup-image">`
+                : '';
+            const popupContent = `
+                <div class="popup">
+                    ${image}
+                    <strong>${popupTitle}</strong><br>
+                    ${popupDescription}
+                    ${categories}
+                    ${popupTaken}
+                </div>
+            `;
+            marker.bindPopup(popupContent);
+            marker.on('click', () => {
+                showDetail(photo);
+            });
+            markers.push(marker);
+        });
+
+        if (markers.length > 0) {
+            const group = L.featureGroup(markers);
+            bounds = group.getBounds().pad(0.3);
+            map.fitBounds(bounds);
+        }
+
+        const homeControl = L.control({ position: 'topleft' });
+        homeControl.onAdd = () => {
+            const container = L.DomUtil.create('div', 'leaflet-bar home-control');
+            const button = L.DomUtil.create('button', '', container);
+            button.type = 'button';
+            button.textContent = 'Home';
+            L.DomEvent.on(button, 'click', (event) => {
+                L.DomEvent.stop(event);
+                if (bounds) {
+                    map.fitBounds(bounds);
+                } else {
+                    map.setView(defaultView.center, defaultView.zoom);
+                }
+            });
+            return container;
+        };
+        homeControl.addTo(map);
+
+        setTimeout(() => {
+            map.invalidateSize();
+            if (bounds) {
+                map.fitBounds(bounds);
+            } else {
+                map.setView(defaultView.center, defaultView.zoom);
+            }
+        }, 200);
+    }
+
+    const openPhotoFromCard = (card) => {
+        if (!card) {
+            return;
+        }
+        const id = Number(card.getAttribute('data-photo-id'));
+        if (!Number.isFinite(id)) {
+            return;
+        }
+        const photo = photoIndex.get(id);
+        if (photo) {
+            suppressScroll = true;
+            showDetail(photo);
+            suppressScroll = false;
+        }
+    };
+
+    document.querySelectorAll('[data-photo-trigger]').forEach(trigger => {
+        trigger.addEventListener('click', (event) => {
+            event.preventDefault();
+            const card = trigger.closest('[data-photo-card]');
+            openPhotoFromCard(card);
+        });
+    });
+
+    document.querySelectorAll('[data-photo-card]').forEach(card => {
+        card.addEventListener('click', (event) => {
+            if (event.target.closest('[data-photo-trigger]')) {
+                return;
+            }
+            if (event.target.closest('form')) {
+                return;
+            }
+            openPhotoFromCard(card);
+        });
+        card.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                openPhotoFromCard(card);
+            }
+        });
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape') {
+            hideDetail();
+        }
+    });
+});

--- a/public/register.php
+++ b/public/register.php
@@ -1,0 +1,62 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$pdo = Database::getInstance($config['db'])->getConnection();
+$auth = new Auth($pdo);
+$userRepo = new UserRepository($pdo);
+
+$error = null;
+$success = null;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+
+    if ($name && $email && $password) {
+        $isFirstUser = $userRepo->countAll() === 0;
+        if ($auth->register($name, $email, $password)) {
+            if ($isFirstUser) {
+                $success = 'Registrierung erfolgreich. Du kannst dich jetzt anmelden.';
+            } else {
+                $success = 'Registrierung erfolgreich. Bitte warte auf die Freigabe durch einen Admin.';
+            }
+        } else {
+            $error = 'Registrierung fehlgeschlagen. E-Mail möglicherweise bereits vergeben.';
+        }
+    } else {
+        $error = 'Bitte alle Felder ausfüllen.';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Geo Photothek - Registrierung</title>
+    <link rel="stylesheet" href="/styles.css">
+</head>
+<body>
+<div class="auth-container">
+    <h1>Geo Photothek</h1>
+    <?php if ($error): ?>
+        <div class="error"><?php echo htmlspecialchars($error, ENT_QUOTES); ?></div>
+    <?php endif; ?>
+    <?php if ($success): ?>
+        <div class="success"><?php echo htmlspecialchars($success, ENT_QUOTES); ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" required>
+
+        <label for="email">E-Mail</label>
+        <input type="email" id="email" name="email" required>
+
+        <label for="password">Passwort</label>
+        <input type="password" id="password" name="password" required>
+
+        <button type="submit">Registrieren</button>
+    </form>
+    <p>Bereits einen Account? <a href="/login.php">Jetzt anmelden</a></p>
+</div>
+</body>
+</html>

--- a/public/shared.php
+++ b/public/shared.php
@@ -1,0 +1,117 @@
+<?php
+require __DIR__ . '/../bootstrap.php';
+
+$token = $_GET['token'] ?? null;
+if (!$token) {
+    http_response_code(404);
+    echo 'Freigabe nicht gefunden.';
+    exit;
+}
+
+$db = Database::getInstance($config['db'])->getConnection();
+$categoryRepo = new CategoryRepository($db);
+$photoRepo = new PhotoRepository($db, $config['app'], $categoryRepo);
+$shareMeta = $photoRepo->shareMetaByToken($token);
+
+if (!$shareMeta) {
+    http_response_code(404);
+    echo 'Freigabe nicht gefunden.';
+    exit;
+}
+
+$photos = $photoRepo->findSharedByToken($token);
+$sharedCategoryNames = $categoryRepo->findNamesByIds($shareMeta['categories']);
+$photosForJs = array_map(static function (array $photo) {
+    $photo['image_url'] = '/uploads/' . $photo['file_path'];
+    $photo['original_image_url'] = !empty($photo['original_file_path'])
+        ? '/uploads/' . $photo['original_file_path']
+        : $photo['image_url'];
+    return $photo;
+}, $photos);
+
+$hasPhotos = !empty($photos);
+?>
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Geteilte Geo Photothek</title>
+    <link rel="stylesheet" href="/styles.css">
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.3/dist/leaflet.js" defer></script>
+    <script>window.PHOTOS = <?php echo json_encode($photosForJs, JSON_UNESCAPED_UNICODE | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP); ?>;</script>
+    <script src="/map.js" defer></script>
+</head>
+<body class="shared-view">
+<header class="topbar">
+    <div class="brand">Geo Photothek (Freigabe)</div>
+</header>
+<main class="shared-layout">
+    <section class="map-panel">
+        <div id="map"></div>
+        <aside class="photo-detail" data-photo-detail>
+            <div class="detail-empty" data-photo-detail-empty>
+                <h3>Details</h3>
+                <p>Wähle eine Pinnadel oder ein Foto, um Details zu sehen.</p>
+            </div>
+            <div class="detail-body hidden" data-photo-detail-body>
+                <button type="button" class="detail-close" data-photo-detail-close aria-label="Detailansicht schließen">&times;</button>
+                <img src="" alt="" data-photo-detail-image>
+                <div class="detail-meta">
+                    <h3 data-photo-detail-title></h3>
+                    <p data-photo-detail-description></p>
+                    <dl>
+                        <div class="detail-row" data-photo-detail-categories-row>
+                            <dt>Kategorien</dt>
+                            <dd data-photo-detail-categories></dd>
+                        </div>
+                        <div class="detail-row" data-photo-detail-coordinates-row>
+                            <dt>Koordinaten</dt>
+                            <dd data-photo-detail-coordinates></dd>
+                        </div>
+                        <div class="detail-row" data-photo-detail-date-row>
+                            <dt>Aufgenommen am</dt>
+                            <dd data-photo-detail-date></dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+        </aside>
+    </section>
+    <section class="photo-grid">
+        <?php if (!empty($sharedCategoryNames)): ?>
+            <div class="shared-hint">Freigegebene Kategorien: <?php echo htmlspecialchars(implode(', ', $sharedCategoryNames), ENT_QUOTES); ?></div>
+        <?php endif; ?>
+        <?php if ($hasPhotos): ?>
+            <?php foreach ($photos as $photo): ?>
+                <?php $photoTitleAttr = htmlspecialchars($photo['title'] ?? 'Ohne Titel', ENT_QUOTES); ?>
+                <article class="photo-card" data-photo-card data-photo-id="<?php echo (int)$photo['id']; ?>" tabindex="0" role="button" aria-label="Foto-Details anzeigen: <?php echo $photoTitleAttr; ?>">
+                    <img src="/uploads/<?php echo htmlspecialchars($photo['file_path'], ENT_QUOTES); ?>" alt="<?php echo htmlspecialchars($photo['title'] ?? 'Foto', ENT_QUOTES); ?>">
+                    <div class="photo-meta">
+                        <h3><?php echo htmlspecialchars($photo['title'] ?? 'Ohne Titel', ENT_QUOTES); ?></h3>
+                        <p><?php echo nl2br(htmlspecialchars($photo['description'] ?? '', ENT_QUOTES)); ?></p>
+                        <?php if (!empty($photo['category_details'])): ?>
+                            <div class="photo-categories">
+                                <?php foreach ($photo['category_details'] as $category): ?>
+                                    <?php $categoryColor = $category['color'] ?? '#3388FF'; ?>
+                                    <span class="category-pill" style="--category-color: <?php echo htmlspecialchars($categoryColor, ENT_QUOTES); ?>"><?php echo htmlspecialchars($category['name'], ENT_QUOTES); ?></span>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif; ?>
+                        <?php if ($photo['latitude'] && $photo['longitude']): ?>
+                            <p>Koordinaten: <?php echo round($photo['latitude'], 5) . ', ' . round($photo['longitude'], 5); ?></p>
+                        <?php endif; ?>
+                        <?php if ($photo['taken_at']): ?>
+                            <p>Aufgenommen am: <?php echo htmlspecialchars($photo['taken_at'], ENT_QUOTES); ?></p>
+                        <?php endif; ?>
+                        <button type="button" class="detail-button" data-photo-trigger>Details anzeigen</button>
+                    </div>
+                </article>
+            <?php endforeach; ?>
+        <?php else: ?>
+            <p class="hint">Für diese Freigabe wurden noch keine passenden Fotos veröffentlicht.</p>
+        <?php endif; ?>
+    </section>
+</main>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,684 @@
+:root {
+    --bg: #0f172a;
+    --card: #1e293b;
+    --accent: #38bdf8;
+    --text: #e2e8f0;
+    --danger: #f87171;
+    --success: #4ade80;
+    font-family: 'Segoe UI', system-ui, sans-serif;
+}
+
+body {
+    margin: 0;
+    background: radial-gradient(circle at top, rgba(59,130,246,0.15), transparent 50%), var(--bg);
+    color: var(--text);
+}
+
+a {
+    color: var(--accent);
+}
+
+.topbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 2rem;
+    background: rgba(15, 23, 42, 0.8);
+    backdrop-filter: blur(12px);
+    box-shadow: 0 10px 30px rgba(15,23,42,0.4);
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+}
+
+.brand {
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.main-nav {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.main-nav a {
+    color: rgba(226, 232, 240, 0.85);
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.main-nav a:hover,
+.main-nav a:focus {
+    background: rgba(56, 189, 248, 0.2);
+    color: rgba(226, 232, 240, 1);
+    outline: none;
+}
+
+.button {
+    background: var(--accent);
+    color: #0f172a;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 600;
+}
+
+.layout {
+    display: grid;
+    grid-template-columns: 320px 1fr;
+    gap: 2rem;
+    padding: 2rem;
+}
+
+#dashboard,
+#upload,
+#map-section,
+#photos,
+#share,
+#categories,
+#approvals {
+    scroll-margin-top: 96px;
+}
+
+.panel {
+    background: rgba(30, 41, 59, 0.85);
+    border-radius: 1rem;
+    padding: 1.5rem;
+    box-shadow: 0 20px 50px rgba(15, 23, 42, 0.4);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.panel form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.panel input,
+.panel textarea,
+.panel button {
+    border: none;
+    border-radius: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: rgba(15, 23, 42, 0.8);
+    color: var(--text);
+}
+
+.panel button {
+    background: linear-gradient(135deg, var(--accent), #6366f1);
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.panel .hint,
+.photo-list .hint,
+.shared-hint {
+    font-size: 0.9rem;
+    color: rgba(226, 232, 240, 0.7);
+    background: rgba(15, 23, 42, 0.4);
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+}
+
+.category-select {
+    border: 1px dashed rgba(56, 189, 248, 0.4);
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+}
+
+.category-select legend {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(226, 232, 240, 0.7);
+    padding: 0 0.5rem;
+}
+
+.checkbox {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.95rem;
+}
+
+.checkbox input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+}
+
+.color-dot {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 50%;
+    background: var(--dot-color, #3388FF);
+    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.45);
+    flex-shrink: 0;
+}
+
+.photo-categories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-top: 0.5rem;
+}
+
+.popup-categories {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    margin-bottom: 0.35rem;
+}
+
+[data-photo-detail-categories] {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+}
+
+.category-pill {
+    --category-color: #3388FF;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    border: 1px solid var(--category-color);
+    background: rgba(148, 163, 184, 0.12);
+    color: #e2e8f0;
+    font-size: 0.75rem;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+}
+
+.category-pill::before {
+    content: '';
+    width: 0.55rem;
+    height: 0.55rem;
+    border-radius: 999px;
+    background: var(--category-color);
+    box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.4);
+}
+
+.category-form,
+.share-form {
+    gap: 0.5rem;
+}
+
+.share {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.share .category-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    max-height: 160px;
+    overflow-y: auto;
+    padding-right: 0.5rem;
+}
+
+.share-form.inline {
+    display: inline-flex;
+    gap: 0.5rem;
+    margin-top: -0.5rem;
+}
+
+.share-form.inline button {
+    background: rgba(56, 189, 248, 0.15);
+    border: 1px solid rgba(56, 189, 248, 0.3);
+}
+
+.share-form .danger {
+    background: rgba(248, 113, 113, 0.2);
+    border: 1px solid rgba(248, 113, 113, 0.5);
+    color: var(--danger);
+}
+
+.category-color-list {
+    list-style: none;
+    margin: 0.75rem 0 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.category-color-form {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.category-color-form .category-name {
+    flex: 1;
+    font-weight: 500;
+}
+
+.category-color-form input[type="color"] {
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+}
+
+.category-color-form button {
+    padding: 0.45rem 0.9rem;
+}
+
+.categories-section,
+.admin-approval,
+.category-manager,
+.share {
+    background: rgba(15, 23, 42, 0.4);
+    border-radius: 1rem;
+    padding: 1rem;
+}
+
+.pending-users {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.pending-users li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    background: rgba(15, 23, 42, 0.5);
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+}
+
+.pending-users form button {
+    background: linear-gradient(135deg, #4ade80, #22c55e);
+}
+
+.popup-image {
+    width: 180px;
+    height: 120px;
+    object-fit: cover;
+    border-radius: 0.5rem;
+    margin-bottom: 0.5rem;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.5);
+}
+
+.popup-categories {
+    font-size: 0.85rem;
+    color: rgba(226, 232, 240, 0.8);
+    margin-bottom: 0.35rem;
+}
+
+.popup-date {
+    font-size: 0.8rem;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.home-control button {
+    width: 100%;
+    height: 32px;
+    border: none;
+    background: rgba(56, 189, 248, 0.9);
+    color: #0f172a;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.home-control button:hover {
+    background: rgba(56, 189, 248, 1);
+}
+
+#map {
+    width: 100%;
+    height: 480px;
+    border-radius: 1rem;
+    overflow: hidden;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.5);
+}
+
+.map-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.map-panel h2 {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+.photo-detail {
+    position: relative;
+    background: rgba(30, 41, 59, 0.85);
+    border-radius: 1rem;
+    padding: 1.25rem;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.55);
+    color: var(--text);
+    overflow: hidden;
+}
+
+.photo-detail .detail-body {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.photo-detail img {
+    width: 100%;
+    max-height: 360px;
+    object-fit: contain;
+    border-radius: 0.75rem;
+    background: rgba(15, 23, 42, 0.8);
+    margin-bottom: 1rem;
+}
+
+.photo-detail .detail-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.photo-detail .detail-meta p {
+    margin: 0;
+    white-space: pre-line;
+}
+
+.photo-detail dl {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.photo-detail dt {
+    font-weight: 600;
+    color: rgba(96, 165, 250, 0.9);
+}
+
+.photo-detail dd {
+    margin: 0;
+}
+
+.detail-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.photo-detail .detail-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.75rem;
+    background: transparent;
+    border: none;
+    color: rgba(226, 232, 240, 0.8);
+    font-size: 1.5rem;
+    cursor: pointer;
+}
+
+.photo-detail .detail-close:hover {
+    color: rgba(226, 232, 240, 1);
+}
+
+.detail-empty {
+    text-align: center;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.hidden {
+    display: none !important;
+}
+
+.detail-button {
+    margin-top: 0.5rem;
+    align-self: flex-start;
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    border: none;
+    background: rgba(56, 189, 248, 0.9);
+    color: #0f172a;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.detail-button:hover {
+    background: rgba(56, 189, 248, 1);
+}
+
+.photo-actions .detail-button {
+    margin-top: 0;
+    padding: 0.35rem 0.85rem;
+}
+
+.photo-list {
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.photo-list-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.photo-list-messages {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    min-width: 200px;
+}
+
+.table-wrapper {
+    overflow-x: auto;
+    background: rgba(15, 23, 42, 0.35);
+    border-radius: 1rem;
+    box-shadow: 0 20px 40px rgba(15, 23, 42, 0.45);
+}
+
+.photo-table {
+    width: 100%;
+    border-collapse: collapse;
+    min-width: 680px;
+}
+
+.photo-table thead {
+    background: rgba(30, 41, 59, 0.85);
+}
+
+.photo-table th {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.photo-table th,
+.photo-table td {
+    padding: 1rem;
+    text-align: left;
+    vertical-align: top;
+}
+
+.photo-table tbody tr:nth-child(even) {
+    background: rgba(15, 23, 42, 0.45);
+}
+
+.photo-table tbody tr:nth-child(odd) {
+    background: rgba(15, 23, 42, 0.35);
+}
+
+.photo-row {
+    transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.photo-row:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.4);
+}
+
+.photo-row:focus {
+    outline: 2px solid rgba(56, 189, 248, 0.8);
+    outline-offset: 2px;
+}
+
+.photo-row.active {
+    box-shadow: 0 18px 32px rgba(56, 189, 248, 0.4);
+    position: relative;
+}
+
+.photo-thumb img {
+    width: 96px;
+    height: 96px;
+    object-fit: cover;
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 20px rgba(15, 23, 42, 0.4);
+}
+
+.photo-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.photo-info strong {
+    font-size: 1.05rem;
+}
+
+.photo-description {
+    color: rgba(226, 232, 240, 0.85);
+}
+
+.photo-meta-line {
+    font-size: 0.9rem;
+    color: rgba(226, 232, 240, 0.7);
+}
+
+.photo-categories-cell {
+    min-width: 180px;
+}
+
+.photo-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    align-items: flex-start;
+}
+
+.photo-actions form {
+    margin: 0;
+}
+
+.danger-link {
+    background: transparent;
+    border: none;
+    color: var(--danger);
+    font-weight: 600;
+    cursor: pointer;
+    padding: 0.35rem 0;
+}
+
+.danger-link:hover,
+.danger-link:focus {
+    text-decoration: underline;
+}
+
+.error,
+.success {
+    padding: 0.75rem 1rem;
+    border-radius: 0.75rem;
+}
+
+.error {
+    background: rgba(248, 113, 113, 0.2);
+    color: var(--danger);
+}
+
+.success {
+    background: rgba(74, 222, 128, 0.2);
+    color: var(--success);
+}
+
+.auth-container {
+    max-width: 360px;
+    margin: 6rem auto;
+    background: rgba(30, 41, 59, 0.9);
+    padding: 2rem;
+    border-radius: 1.25rem;
+    box-shadow: 0 20px 60px rgba(15, 23, 42, 0.6);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.auth-container form {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.auth-container input,
+.auth-container button {
+    border: none;
+    border-radius: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: rgba(15, 23, 42, 0.8);
+    color: var(--text);
+}
+
+.auth-container button {
+    background: linear-gradient(135deg, var(--accent), #6366f1);
+    cursor: pointer;
+    font-weight: 600;
+}
+
+.share-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.share-link input {
+    background: rgba(15, 23, 42, 0.8);
+    border: 1px solid rgba(56, 189, 248, 0.3);
+}
+
+.shared-layout {
+    display: grid;
+    grid-template-columns: 1fr 360px;
+    gap: 2rem;
+    padding: 2rem;
+}
+
+@media (max-width: 900px) {
+    .layout {
+        grid-template-columns: 1fr;
+    }
+    .shared-layout {
+        grid-template-columns: 1fr;
+    }
+}

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -1,0 +1,97 @@
+<?php
+
+class Auth
+{
+    private \PDO $pdo;
+    private ?string $lastError = null;
+
+    public function __construct(\PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function register(string $name, string $email, string $password): bool
+    {
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $userRepo = new UserRepository($this->pdo);
+        $isFirstUser = $userRepo->countAll() === 0;
+
+        $stmt = $this->pdo->prepare('INSERT INTO users (name, email, password_hash, is_admin, is_approved) VALUES (:name, :email, :password, :is_admin, :is_approved)');
+        try {
+            return $stmt->execute([
+                ':name' => $name,
+                ':email' => $email,
+                ':password' => $hash,
+                ':is_admin' => $isFirstUser ? 1 : 0,
+                ':is_approved' => $isFirstUser ? 1 : 0,
+            ]);
+        } catch (\PDOException $e) {
+            return false;
+        }
+    }
+
+    public function attempt(string $email, string $password): bool
+    {
+        $this->lastError = null;
+        $stmt = $this->pdo->prepare('SELECT * FROM users WHERE email = :email');
+        $stmt->execute([':email' => $email]);
+        $user = $stmt->fetch(\PDO::FETCH_ASSOC);
+        if (!$user) {
+            $this->lastError = 'Anmeldung fehlgeschlagen.';
+            return false;
+        }
+        if (password_verify($password, $user['password_hash'])) {
+            if (!(bool)$user['is_approved']) {
+                $this->lastError = 'Dein Account ist noch nicht freigeschaltet. Bitte den Admin kontaktieren.';
+                return false;
+            }
+            $_SESSION['user'] = [
+                'id' => $user['id'],
+                'name' => $user['name'],
+                'email' => $user['email'],
+                'is_admin' => (bool)$user['is_admin'],
+            ];
+            return true;
+        }
+        $this->lastError = 'Anmeldung fehlgeschlagen.';
+        return false;
+    }
+
+    public function logout(): void
+    {
+        unset($_SESSION['user']);
+    }
+
+    public function user(): ?array
+    {
+        return $_SESSION['user'] ?? null;
+    }
+
+    public function isAdmin(): bool
+    {
+        $user = $this->user();
+        return (bool)($user['is_admin'] ?? false);
+    }
+
+    public function requireLogin(): void
+    {
+        if (!$this->user()) {
+            header('Location: /login.php');
+            exit;
+        }
+    }
+
+    public function requireAdmin(): void
+    {
+        if (!$this->isAdmin()) {
+            http_response_code(403);
+            echo 'Zugriff verweigert';
+            exit;
+        }
+    }
+
+    public function lastError(): ?string
+    {
+        return $this->lastError;
+    }
+}

--- a/src/CategoryRepository.php
+++ b/src/CategoryRepository.php
@@ -1,0 +1,228 @@
+<?php
+
+class CategoryRepository
+{
+    private \PDO $pdo;
+
+    public function __construct(\PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function create(int $userId, string $name, ?string $color = null): ?int
+    {
+        $name = trim($name);
+        if ($name === '') {
+            return null;
+        }
+
+        $normalizedColor = $this->normalizeColor($color);
+        if ($normalizedColor === null) {
+            return null;
+        }
+
+        $stmt = $this->pdo->prepare('INSERT INTO categories (user_id, name, color) VALUES (:user_id, :name, :color)');
+        try {
+            $stmt->execute([
+                ':user_id' => $userId,
+                ':name' => $name,
+                ':color' => $normalizedColor,
+            ]);
+        } catch (\PDOException $e) {
+            // Duplicate entries are ignored gracefully
+            return null;
+        }
+
+        return (int)$this->pdo->lastInsertId();
+    }
+
+    public function findByUser(int $userId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT id, name, color FROM categories WHERE user_id = :user_id ORDER BY name');
+        $stmt->execute([':user_id' => $userId]);
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    public function updateColor(int $categoryId, int $userId, string $color): bool
+    {
+        $normalizedColor = $this->normalizeColor($color);
+        if ($normalizedColor === null) {
+            return false;
+        }
+
+        $stmt = $this->pdo->prepare('UPDATE categories SET color = :color WHERE id = :id AND user_id = :user_id');
+        $stmt->execute([
+            ':color' => $normalizedColor,
+            ':id' => $categoryId,
+            ':user_id' => $userId,
+        ]);
+
+        if ($stmt->rowCount() > 0) {
+            return true;
+        }
+
+        $checkStmt = $this->pdo->prepare('SELECT color FROM categories WHERE id = :id AND user_id = :user_id');
+        $checkStmt->execute([
+            ':id' => $categoryId,
+            ':user_id' => $userId,
+        ]);
+
+        $existing = $checkStmt->fetchColumn();
+        if ($existing === false) {
+            return false;
+        }
+
+        return strtoupper((string)$existing) === $normalizedColor;
+    }
+
+    public function filterIdsForUser(int $userId, array $categoryIds): array
+    {
+        $categoryIds = array_values(array_unique(array_map('intval', $categoryIds)));
+        if (empty($categoryIds)) {
+            return [];
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($categoryIds), '?'));
+        $sql = sprintf(
+            'SELECT id FROM categories WHERE user_id = ? AND id IN (%s)',
+            $placeholders
+        );
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(array_merge([$userId], $categoryIds));
+
+        return array_map('intval', $stmt->fetchAll(\PDO::FETCH_COLUMN));
+    }
+
+    public function syncPhotoCategories(int $photoId, int $userId, array $categoryIds): void
+    {
+        $allowedIds = $this->filterIdsForUser($userId, $categoryIds);
+
+        $manageTransaction = !$this->pdo->inTransaction();
+        if ($manageTransaction) {
+            $this->pdo->beginTransaction();
+        }
+        try {
+            $deleteStmt = $this->pdo->prepare('DELETE FROM photo_categories WHERE photo_id = :photo_id');
+            $deleteStmt->execute([':photo_id' => $photoId]);
+
+            if (!empty($allowedIds)) {
+                $insertStmt = $this->pdo->prepare('INSERT INTO photo_categories (photo_id, category_id) VALUES (:photo_id, :category_id)');
+                foreach ($allowedIds as $categoryId) {
+                    $insertStmt->execute([
+                        ':photo_id' => $photoId,
+                        ':category_id' => $categoryId,
+                    ]);
+                }
+            }
+
+            if ($manageTransaction) {
+                $this->pdo->commit();
+            }
+        } catch (\Throwable $e) {
+            if ($manageTransaction && $this->pdo->inTransaction()) {
+                $this->pdo->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    public function mapCategoriesForPhotos(array $photoIds): array
+    {
+        $photoIds = array_values(array_unique(array_map('intval', $photoIds)));
+        if (empty($photoIds)) {
+            return [];
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($photoIds), '?'));
+        $sql = sprintf(
+            'SELECT pc.photo_id, c.id, c.name, c.color FROM photo_categories pc JOIN categories c ON c.id = pc.category_id WHERE pc.photo_id IN (%s) ORDER BY c.name',
+            $placeholders
+        );
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($photoIds);
+
+        $result = [];
+        while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
+            $photoId = (int)$row['photo_id'];
+            if (!isset($result[$photoId])) {
+                $result[$photoId] = [];
+            }
+            $result[$photoId][] = [
+                'id' => (int)$row['id'],
+                'name' => $row['name'],
+                'color' => $row['color'],
+            ];
+        }
+
+        return $result;
+    }
+
+    public function syncShareCategories(int $shareMapId, int $userId, array $categoryIds): void
+    {
+        $allowedIds = $this->filterIdsForUser($userId, $categoryIds);
+
+        $manageTransaction = !$this->pdo->inTransaction();
+        if ($manageTransaction) {
+            $this->pdo->beginTransaction();
+        }
+        try {
+            $deleteStmt = $this->pdo->prepare('DELETE FROM shared_map_categories WHERE shared_map_id = :shared_map_id');
+            $deleteStmt->execute([':shared_map_id' => $shareMapId]);
+
+            if (!empty($allowedIds)) {
+                $insertStmt = $this->pdo->prepare('INSERT INTO shared_map_categories (shared_map_id, category_id) VALUES (:shared_map_id, :category_id)');
+                foreach ($allowedIds as $categoryId) {
+                    $insertStmt->execute([
+                        ':shared_map_id' => $shareMapId,
+                        ':category_id' => $categoryId,
+                    ]);
+                }
+            }
+
+            if ($manageTransaction) {
+                $this->pdo->commit();
+            }
+        } catch (\Throwable $e) {
+            if ($manageTransaction && $this->pdo->inTransaction()) {
+                $this->pdo->rollBack();
+            }
+            throw $e;
+        }
+    }
+
+    public function findShareCategoryIds(int $shareMapId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT category_id FROM shared_map_categories WHERE shared_map_id = :shared_map_id ORDER BY category_id');
+        $stmt->execute([':shared_map_id' => $shareMapId]);
+        return array_map('intval', $stmt->fetchAll(\PDO::FETCH_COLUMN));
+    }
+
+    public function findNamesByIds(array $categoryIds): array
+    {
+        $categoryIds = array_values(array_unique(array_map('intval', $categoryIds)));
+        if (empty($categoryIds)) {
+            return [];
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($categoryIds), '?'));
+        $sql = sprintf('SELECT name FROM categories WHERE id IN (%s) ORDER BY name', $placeholders);
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($categoryIds);
+
+        return $stmt->fetchAll(\PDO::FETCH_COLUMN);
+    }
+
+    private function normalizeColor(?string $color): ?string
+    {
+        $color = trim((string)$color);
+        if ($color === '') {
+            return '#3388FF';
+        }
+
+        if (!preg_match('/^#([0-9a-fA-F]{6})$/', $color, $matches)) {
+            return null;
+        }
+
+        return '#' . strtoupper($matches[1]);
+    }
+}

--- a/src/Database.php
+++ b/src/Database.php
@@ -1,0 +1,38 @@
+<?php
+
+class Database
+{
+    private static ?Database $instance = null;
+    private \PDO $pdo;
+
+    private function __construct(array $config)
+    {
+        $dsn = sprintf(
+            'mysql:host=%s;port=%s;dbname=%s;charset=%s',
+            $config['host'],
+            $config['port'],
+            $config['database'],
+            $config['charset'] ?? 'utf8mb4'
+        );
+
+        $this->pdo = new \PDO(
+            $dsn,
+            $config['username'],
+            $config['password'],
+            [\PDO::ATTR_ERRMODE => \PDO::ERRMODE_EXCEPTION]
+        );
+    }
+
+    public static function getInstance(array $config): Database
+    {
+        if (!self::$instance) {
+            self::$instance = new self($config);
+        }
+        return self::$instance;
+    }
+
+    public function getConnection(): \PDO
+    {
+        return $this->pdo;
+    }
+}

--- a/src/PhotoRepository.php
+++ b/src/PhotoRepository.php
@@ -1,0 +1,220 @@
+<?php
+
+class PhotoRepository
+{
+    private \PDO $pdo;
+    private array $config;
+    private CategoryRepository $categories;
+
+    public function __construct(\PDO $pdo, array $config, ?CategoryRepository $categories = null)
+    {
+        $this->pdo = $pdo;
+        $this->config = $config;
+        $this->categories = $categories ?? new CategoryRepository($pdo);
+    }
+
+    public function create(array $data): int
+    {
+        $stmt = $this->pdo->prepare('INSERT INTO photos (user_id, title, description, file_path, original_file_path, latitude, longitude, taken_at) VALUES (:user_id, :title, :description, :file_path, :original_file_path, :latitude, :longitude, :taken_at)');
+        $stmt->execute([
+            ':user_id' => $data['user_id'],
+            ':title' => $data['title'] ?? null,
+            ':description' => $data['description'] ?? null,
+            ':file_path' => $data['file_path'],
+            ':original_file_path' => $data['original_file_path'],
+            ':latitude' => $data['latitude'],
+            ':longitude' => $data['longitude'],
+            ':taken_at' => $data['taken_at'] ?? null,
+        ]);
+        return (int)$this->pdo->lastInsertId();
+    }
+
+    public function findByUser(int $userId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM photos WHERE user_id = :user_id ORDER BY created_at DESC');
+        $stmt->execute([':user_id' => $userId]);
+        $photos = $stmt->fetchAll(\PDO::FETCH_ASSOC);
+
+        return $this->hydrateCategories($photos);
+    }
+
+    public function findOne(int $photoId, int $userId): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM photos WHERE id = :id AND user_id = :user_id LIMIT 1');
+        $stmt->execute([
+            ':id' => $photoId,
+            ':user_id' => $userId,
+        ]);
+
+        $photo = $stmt->fetch(\PDO::FETCH_ASSOC);
+        if (!$photo) {
+            return null;
+        }
+
+        $hydrated = $this->hydrateCategories([$photo]);
+
+        return $hydrated[0] ?? null;
+    }
+
+    public function findSharedByToken(string $token): array
+    {
+        $shareMap = $this->shareMetaByToken($token);
+        if (!$shareMap) {
+            return [];
+        }
+
+        $shareMapId = (int)$shareMap['id'];
+        $userId = (int)$shareMap['user_id'];
+        $allowedCategories = $shareMap['categories'];
+
+        $photos = $this->findPhotosForShare($userId, $allowedCategories);
+
+        return $this->hydrateCategories($photos);
+    }
+
+    public function upsertShareSettings(int $userId, array $categoryIds, bool $regenerateToken = false): string
+    {
+        $this->pdo->beginTransaction();
+        try {
+            $stmt = $this->pdo->prepare('SELECT id, share_token FROM shared_maps WHERE user_id = :user_id');
+            $stmt->execute([':user_id' => $userId]);
+            $shareMap = $stmt->fetch(\PDO::FETCH_ASSOC);
+
+            $token = $shareMap ? $shareMap['share_token'] : bin2hex(random_bytes(16));
+            if ($regenerateToken || !$shareMap) {
+                $token = bin2hex(random_bytes(16));
+            }
+
+            if ($shareMap) {
+                $updateStmt = $this->pdo->prepare('UPDATE shared_maps SET share_token = :share_token WHERE id = :id');
+                $updateStmt->execute([
+                    ':share_token' => $token,
+                    ':id' => $shareMap['id'],
+                ]);
+                $shareMapId = (int)$shareMap['id'];
+            } else {
+                $insertStmt = $this->pdo->prepare('INSERT INTO shared_maps (user_id, share_token) VALUES (:user_id, :share_token)');
+                $insertStmt->execute([
+                    ':user_id' => $userId,
+                    ':share_token' => $token,
+                ]);
+                $shareMapId = (int)$this->pdo->lastInsertId();
+            }
+
+            $this->categories->syncShareCategories($shareMapId, $userId, $categoryIds);
+            $this->pdo->commit();
+        } catch (\Throwable $e) {
+            $this->pdo->rollBack();
+            throw $e;
+        }
+
+        return $token;
+    }
+
+    public function deleteShare(int $userId): void
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM shared_maps WHERE user_id = :user_id');
+        $stmt->execute([':user_id' => $userId]);
+    }
+
+    public function getShareSettings(int $userId): array
+    {
+        $stmt = $this->pdo->prepare('SELECT id, share_token FROM shared_maps WHERE user_id = :user_id');
+        $stmt->execute([':user_id' => $userId]);
+        $shareMap = $stmt->fetch(\PDO::FETCH_ASSOC);
+        if (!$shareMap) {
+            return [
+                'url' => null,
+                'token' => null,
+                'categories' => [],
+            ];
+        }
+
+        $categoryIds = $this->categories->findShareCategoryIds((int)$shareMap['id']);
+
+        return [
+            'url' => rtrim($this->config['base_url'], '/') . '/shared.php?token=' . $shareMap['share_token'],
+            'token' => $shareMap['share_token'],
+            'categories' => $categoryIds,
+        ];
+    }
+
+    private function hydrateCategories(array $photos): array
+    {
+        if (empty($photos)) {
+            return $photos;
+        }
+
+        $photoIds = array_column($photos, 'id');
+        $categoryMap = $this->categories->mapCategoriesForPhotos($photoIds);
+
+        return array_map(function (array $photo) use ($categoryMap) {
+            $photoId = (int)$photo['id'];
+            $categoryRows = $categoryMap[$photoId] ?? [];
+            $photo['categories'] = array_map(static function (array $category) {
+                return $category['name'];
+            }, $categoryRows);
+            $photo['category_ids'] = array_map(static function (array $category) {
+                return (int)$category['id'];
+            }, $categoryRows);
+            $photo['category_details'] = array_map(static function (array $category) {
+                return [
+                    'id' => (int)$category['id'],
+                    'name' => $category['name'],
+                    'color' => $category['color'],
+                ];
+            }, $categoryRows);
+            $photo['primary_color'] = $categoryRows[0]['color'] ?? null;
+            return $photo;
+        }, $photos);
+    }
+
+    private function findPhotosForShare(int $userId, array $allowedCategories): array
+    {
+        if (empty($allowedCategories)) {
+            $stmt = $this->pdo->prepare('SELECT * FROM photos WHERE user_id = :user_id ORDER BY created_at DESC');
+            $stmt->execute([':user_id' => $userId]);
+            return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        }
+
+        $placeholders = implode(', ', array_fill(0, count($allowedCategories), '?'));
+        $sql = sprintf(
+            'SELECT p.* FROM photos p
+             LEFT JOIN photo_categories pc ON pc.photo_id = p.id
+             WHERE p.user_id = ?
+             GROUP BY p.id
+             HAVING SUM(CASE WHEN pc.category_id IN (%s) THEN 1 ELSE 0 END) > 0
+             ORDER BY p.created_at DESC',
+            $placeholders
+        );
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(array_merge([$userId], $allowedCategories));
+
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    public function shareMetaByToken(string $token): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT id, user_id, share_token FROM shared_maps WHERE share_token = :token');
+        $stmt->execute([':token' => $token]);
+        $shareMap = $stmt->fetch(\PDO::FETCH_ASSOC);
+        if (!$shareMap) {
+            return null;
+        }
+
+        $shareMap['categories'] = $this->categories->findShareCategoryIds((int)$shareMap['id']);
+
+        return $shareMap;
+    }
+
+    public function delete(int $photoId, int $userId): bool
+    {
+        $stmt = $this->pdo->prepare('DELETE FROM photos WHERE id = :id AND user_id = :user_id');
+        $stmt->execute([
+            ':id' => $photoId,
+            ':user_id' => $userId,
+        ]);
+
+        return $stmt->rowCount() > 0;
+    }
+}

--- a/src/PhotoService.php
+++ b/src/PhotoService.php
@@ -1,0 +1,273 @@
+<?php
+
+class PhotoService
+{
+    private PhotoRepository $photos;
+    private CategoryRepository $categories;
+    private array $appConfig;
+
+    public function __construct(PhotoRepository $photos, CategoryRepository $categories, array $appConfig)
+    {
+        $this->photos = $photos;
+        $this->categories = $categories;
+        $this->appConfig = $appConfig;
+    }
+
+    public function handleUpload(array $file, array $input, int $userId, array $categoryIds = []): array
+    {
+        $this->validateUpload($file);
+
+        $targetDir = $this->appConfig['upload_dir'];
+        $originalDir = $this->appConfig['original_upload_dir'] ?? ($targetDir . '/originals');
+        if (!is_dir($targetDir)) {
+            mkdir($targetDir, 0775, true);
+        }
+        if (!is_dir($originalDir)) {
+            mkdir($originalDir, 0775, true);
+        }
+
+        $extension = strtolower(pathinfo($file['name'], PATHINFO_EXTENSION));
+        $filename = uniqid('photo_', true) . ($extension ? '.' . $extension : '');
+        $originalDestination = rtrim($originalDir, '/') . '/' . $filename;
+
+        if (!move_uploaded_file($file['tmp_name'], $originalDestination)) {
+            throw new RuntimeException('Upload fehlgeschlagen.');
+        }
+
+        $normalizedTarget = str_replace('\\', '/', rtrim(realpath($targetDir) ?: $targetDir, '/'));
+        $normalizedOriginal = str_replace('\\', '/', rtrim(realpath($originalDir) ?: $originalDir, '/'));
+        $originalRelativeDir = '';
+        if ($normalizedTarget !== '' && $normalizedOriginal !== '' && strpos($normalizedOriginal, $normalizedTarget) === 0) {
+            $suffix = trim(substr($normalizedOriginal, strlen($normalizedTarget)), '/');
+            $originalRelativeDir = $suffix;
+        }
+        $originalRelativePath = $originalRelativeDir !== '' ? $originalRelativeDir . '/' . $filename : $filename;
+
+        $destination = rtrim($targetDir, '/') . '/' . $filename;
+        $this->createDisplayVersion($originalDestination, $destination);
+
+        $metadata = $this->extractMetadata($originalDestination);
+        $takenAt = $metadata['taken_at'] ?? null;
+
+        $photoId = $this->photos->create([
+            'user_id' => $userId,
+            'title' => $input['title'] ?? null,
+            'description' => $input['description'] ?? null,
+            'file_path' => $filename,
+            'original_file_path' => $originalRelativePath,
+            'latitude' => $metadata['latitude'],
+            'longitude' => $metadata['longitude'],
+            'taken_at' => $takenAt,
+        ]);
+
+        $this->categories->syncPhotoCategories($photoId, $userId, $categoryIds);
+
+        $photos = $this->photos->findByUser($userId);
+        $created = null;
+        foreach ($photos as $row) {
+            if ((int)$row['id'] === $photoId) {
+                $created = $row;
+                break;
+            }
+        }
+
+        return $created ?? [
+            'id' => $photoId,
+            'file_path' => $filename,
+            'original_file_path' => $originalRelativePath,
+            'latitude' => $metadata['latitude'],
+            'longitude' => $metadata['longitude'],
+            'taken_at' => $takenAt,
+            'categories' => [],
+            'category_ids' => $categoryIds,
+            'category_details' => [],
+            'primary_color' => null,
+        ];
+    }
+
+    public function deletePhoto(int $photoId, int $userId): void
+    {
+        $photo = $this->photos->findOne($photoId, $userId);
+        if (!$photo) {
+            throw new RuntimeException('Foto nicht gefunden.');
+        }
+
+        $baseDir = rtrim($this->appConfig['upload_dir'], '/');
+        if ($baseDir === '') {
+            throw new RuntimeException('Upload-Verzeichnis nicht konfiguriert.');
+        }
+
+        $paths = [];
+        if (!empty($photo['file_path'])) {
+            $paths[] = $baseDir . '/' . ltrim($photo['file_path'], '/');
+        }
+        if (!empty($photo['original_file_path'])) {
+            $paths[] = $baseDir . '/' . ltrim($photo['original_file_path'], '/');
+        }
+
+        foreach ($paths as $path) {
+            if (is_file($path)) {
+                @unlink($path);
+            }
+        }
+
+        $this->photos->delete($photoId, $userId);
+    }
+
+    private function validateUpload(array $file): void
+    {
+        if ($file['error'] !== UPLOAD_ERR_OK) {
+            throw new RuntimeException('Ungültiger Upload: ' . $file['error']);
+        }
+        if ($file['size'] > $this->appConfig['max_upload_size']) {
+            throw new RuntimeException('Datei zu groß.');
+        }
+        $finfo = new finfo(FILEINFO_MIME_TYPE);
+        $mime = $finfo->file($file['tmp_name']);
+        if (!in_array($mime, $this->appConfig['allowed_types'])) {
+            throw new RuntimeException('Dateityp nicht erlaubt.');
+        }
+    }
+
+    private function extractMetadata(string $filePath): array
+    {
+        $latitude = null;
+        $longitude = null;
+        $takenAt = null;
+
+        if (function_exists('exif_read_data')) {
+            $exif = @exif_read_data($filePath, 0, true);
+            if ($exif && isset($exif['GPS'])) {
+                $latitude = $this->gpsToDecimal($exif['GPS']['GPSLatitude'] ?? null, $exif['GPS']['GPSLatitudeRef'] ?? null);
+                $longitude = $this->gpsToDecimal($exif['GPS']['GPSLongitude'] ?? null, $exif['GPS']['GPSLongitudeRef'] ?? null);
+            }
+            if ($exif && isset($exif['EXIF']['DateTimeOriginal'])) {
+                $takenAt = date('Y-m-d H:i:s', strtotime($exif['EXIF']['DateTimeOriginal']));
+            }
+        }
+
+        return [
+            'latitude' => $latitude,
+            'longitude' => $longitude,
+            'taken_at' => $takenAt,
+        ];
+    }
+
+    private function gpsToDecimal(?array $coordinate, ?string $hemisphere): ?float
+    {
+        if (!$coordinate || !$hemisphere) {
+            return null;
+        }
+
+        $degrees = $this->gpsPartToFloat($coordinate[0] ?? '0/1');
+        $minutes = $this->gpsPartToFloat($coordinate[1] ?? '0/1');
+        $seconds = $this->gpsPartToFloat($coordinate[2] ?? '0/1');
+
+        $decimal = $degrees + ($minutes / 60) + ($seconds / 3600);
+        if (in_array(strtoupper($hemisphere), ['S', 'W'], true)) {
+            $decimal *= -1;
+        }
+        return $decimal;
+    }
+
+    private function gpsPartToFloat(string $part): float
+    {
+        $components = explode('/', $part);
+        if (count($components) === 2 && (float)$components[1] !== 0.0) {
+            return (float)$components[0] / (float)$components[1];
+        }
+        return (float)$part;
+    }
+
+    private function createDisplayVersion(string $source, string $destination): void
+    {
+        $maxDimension = $this->appConfig['display_max_dimension'] ?? 1600;
+        if (!is_numeric($maxDimension) || (float)$maxDimension <= 0) {
+            copy($source, $destination);
+            return;
+        }
+        $maxDimension = (float)$maxDimension;
+
+        if (!extension_loaded('gd')) {
+            copy($source, $destination);
+            return;
+        }
+
+        $imageInfo = @getimagesize($source);
+        if ($imageInfo === false) {
+            copy($source, $destination);
+            return;
+        }
+
+        [$width, $height, $type] = $imageInfo;
+
+        if ($width <= $maxDimension && $height <= $maxDimension) {
+            copy($source, $destination);
+            return;
+        }
+
+        $ratio = min($maxDimension / $width, $maxDimension / $height);
+        $newWidth = (int)max(1, round($width * $ratio));
+        $newHeight = (int)max(1, round($height * $ratio));
+
+        switch ($type) {
+            case IMAGETYPE_JPEG:
+                $sourceImage = imagecreatefromjpeg($source);
+                $output = $this->resampleImage($sourceImage, $width, $height, $newWidth, $newHeight);
+                if ($output && imagejpeg($output, $destination, 85)) {
+                    imagedestroy($output);
+                } else {
+                    copy($source, $destination);
+                    if ($output) {
+                        imagedestroy($output);
+                    }
+                }
+                if ($sourceImage) {
+                    imagedestroy($sourceImage);
+                }
+                break;
+            case IMAGETYPE_PNG:
+                $sourceImage = imagecreatefrompng($source);
+                if ($sourceImage === false) {
+                    copy($source, $destination);
+                    break;
+                }
+                $output = imagecreatetruecolor($newWidth, $newHeight);
+                if ($output === false) {
+                    imagedestroy($sourceImage);
+                    copy($source, $destination);
+                    break;
+                }
+                imagealphablending($output, false);
+                imagesavealpha($output, true);
+                $resampled = imagecopyresampled($output, $sourceImage, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
+                if ($resampled && imagepng($output, $destination, 6)) {
+                    // success
+                } else {
+                    copy($source, $destination);
+                }
+                imagedestroy($sourceImage);
+                imagedestroy($output);
+                break;
+            default:
+                copy($source, $destination);
+        }
+    }
+
+    private function resampleImage($sourceImage, int $width, int $height, int $newWidth, int $newHeight)
+    {
+        if ($sourceImage === false) {
+            return null;
+        }
+        $output = imagecreatetruecolor($newWidth, $newHeight);
+        if ($output === false) {
+            return null;
+        }
+        $resampled = imagecopyresampled($output, $sourceImage, 0, 0, 0, 0, $newWidth, $newHeight, $width, $height);
+        if ($resampled === false) {
+            imagedestroy($output);
+            return null;
+        }
+        return $output;
+    }
+}

--- a/src/UserRepository.php
+++ b/src/UserRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+class UserRepository
+{
+    private \PDO $pdo;
+
+    public function __construct(\PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
+
+    public function countAll(): int
+    {
+        $stmt = $this->pdo->query('SELECT COUNT(*) FROM users');
+        return (int)$stmt->fetchColumn();
+    }
+
+    public function findPending(): array
+    {
+        $stmt = $this->pdo->query('SELECT id, name, email, created_at FROM users WHERE is_approved = 0 ORDER BY created_at');
+        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    public function approve(int $userId): void
+    {
+        $stmt = $this->pdo->prepare('UPDATE users SET is_approved = 1 WHERE id = :id');
+        $stmt->execute([':id' => $userId]);
+    }
+
+    public function findById(int $userId): ?array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM users WHERE id = :id');
+        $stmt->execute([':id' => $userId]);
+        $user = $stmt->fetch(\PDO::FETCH_ASSOC);
+        return $user ?: null;
+    }
+}


### PR DESCRIPTION
## Summary
- relocate the installer to `public/install.php` with a styled browser UI and CLI fallback that can seed or upgrade the schema
- allow saving database credentials directly into `config/config.php` when missing so the installer can run without manual edits
- refresh the README setup steps to point to the public installer and document follow-up configuration adjustments

## Testing
- find . -name "*.php" -print0 | xargs -0 -I{} php -l {}


------
https://chatgpt.com/codex/tasks/task_e_68e0331e59ec83339fef40d6e19df28f